### PR TITLE
Fix saving consent for links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager/container.js
+++ b/src/consent-manager/container.js
@@ -184,6 +184,19 @@ export default class Container extends PureComponent {
       return
     }
 
+    // We imply consent when user clicks on any link inside or
+    // outside of consent-manager
+    if (implyConsentType === 'links') {
+      const link = e.target.closest('a')
+
+      if (link === null || link.getAttribute('href') === null) {
+        return
+      }
+
+      saveConsent(undefined, false, true)
+      return
+    }
+
     // Ignore propogated clicks from inside the consent manager
     if (
       (this.banner && this.banner.contains(e.target)) ||
@@ -191,14 +204,6 @@ export default class Container extends PureComponent {
       (this.cancelDialog && this.cancelDialog.contains(e.target))
     ) {
       return
-    }
-
-    if (implyConsentType === 'links') {
-      const link = e.target.closest('a')
-
-      if (link === null || link.getAttribute('href') === null) {
-        return
-      }
     }
 
     saveConsent(undefined, false, true)


### PR DESCRIPTION
**Changes**

Handling saving consent on clicking links inside consent-popup. Previously it was saved only if click on link was happened outside consent-popup.

![Screenshot 2019-05-22 at 15 29 23](https://user-images.githubusercontent.com/1271366/58182964-6efcfe00-7ca6-11e9-926b-8a5266e43b77.png)
