### PR TITLE
[PHX-2249] Hide cookie-banner when it was implied

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@segment/consent-manager",
+  "name": "@healthbridgeltd/consent-manager",
   "version": "1.5.4",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager/container.js
+++ b/src/consent-manager/container.js
@@ -194,7 +194,7 @@ export default class Container extends PureComponent {
         return
       }
 
-      saveConsent(undefined, false, true)
+      saveConsent(undefined, false, false)
       return
     }
 


### PR DESCRIPTION
Return `false` for the third argument of `saveContent`, which is `isBannerVisible`.

This automatically saves to the `tracking-preference` cookie and change `isBannerVisible` to false, and this is the trigger of showing the banner or not.

```
{
    "version": 1,
    "destinations": {
        "Amazon S3": false,
        "Customer.io": false,
        "Webhooks": false
    },
    "custom": {
        "marketingAndAnalytics": false,
        "advertising": false,
        "functional": true
    },
    "isBannerVisible": false // here
}
```