### PR TITLE
[PHX-2259] Reordering HTML elements based on the new design 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthbridgeltd/consent-manager",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthbridgeltd/consent-manager",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager/banner.js
+++ b/src/consent-manager/banner.js
@@ -86,7 +86,7 @@ export default class Banner extends PureComponent {
         <Content>
           <P>{content}</P>
         </Content>
-        <div className="ConsentCtaContainer">
+        <div className="ConsentButtonContainer">
           <CloseButton
             className="Button Button--primary"
             type="button"

--- a/src/consent-manager/banner.js
+++ b/src/consent-manager/banner.js
@@ -85,22 +85,23 @@ export default class Banner extends PureComponent {
       >
         <Content>
           <P>{content}</P>
+        </Content>
+        <div className="ConsentCtaContainer">
+          <CloseButton
+            className="Button Button--primary"
+            type="button"
+            title={translate('ui.accept_all')}
+            aria-label={translate('ui.accept_all')}
+            onClick={onAccept}
+          >
+            {translate('ui.accept_all')}
+          </CloseButton>
           <P>
             <button type="button" onClick={onChangePreferences}>
               {subContent}
             </button>
           </P>
-        </Content>
-
-        <CloseButton
-          className="Button Button--primary"
-          type="button"
-          title={translate('ui.accept_all')}
-          aria-label={translate('ui.accept_all')}
-          onClick={onAccept}
-        >
-          {translate('ui.accept_all')}
-        </CloseButton>
+        </div>
       </Root>
     )
   }


### PR DESCRIPTION
## Overview
Reordering the HTML elements.

- [x] [[PHX-2259](https://zavamed.atlassian.net/browse/PHX-2259)]
- [x] Add relevant title (with ticket number)
- [x] Ensure your branch is rebased on `master`, and squash your commits (per feature/isolated changes)
- [ ] Add Diff - A11y - e2e where applicable
- [x] TESTED on iphone / android / IE11 / Chrome 60+ / Safari 5.1+ / FF 53+
- [x] Add steps to reproduce functionality
- [x] Provide any snapshots of having tested on above browsers and devices if applicable
- [x] Add a main `assignee` to review PR (multiple if necessary)

### Changelog
Reordered the HTML elements so they can CTA buttons can be inside the same wrapper.

### Steps to reproduce
Install the new version of the `consent-manager` and expect the CTA buttons to have changed place.

### Expected results
The "More Options" link should always be under the "Accept button", as also shown in the images below:

![image](https://user-images.githubusercontent.com/13893873/68785368-fe6fe200-0635-11ea-8aac-fcb2c250ee26.png)

![image](https://user-images.githubusercontent.com/13893873/68785370-00d23c00-0636-11ea-8bfe-29925a4f39a6.png)